### PR TITLE
Containerize the application and introduce an Nginx proxy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ build/
 
 ### VS Code ###
 .vscode/
+/certs/

--- a/.gitignore
+++ b/.gitignore
@@ -31,4 +31,4 @@ build/
 
 ### VS Code ###
 .vscode/
-/certs/
+/nginx/certs/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+# TODO agree on a stable version
+FROM eclipse-temurin:21.0.3_9-jre
+
+VOLUME /tmp
+
+EXPOSE 8080
+
+COPY target/*.jar /app/app.jar
+
+# Create run user and set ownership to /app
+RUN groupadd -g 1001 javauser && useradd --home-dir /app --uid 1001 --gid 1001 --shell /bin/bash javauser
+RUN chown -R javauser:javauser /app
+USER javauser
+
+ENTRYPOINT ["java","-jar","/app/app.jar"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # TODO agree on a stable version
-FROM eclipse-temurin:21.0.3_9-jre
+FROM eclipse-temurin:latest
 
 VOLUME /tmp
 

--- a/README.md
+++ b/README.md
@@ -11,24 +11,26 @@ The Dynamic Email Generator is a service designed to create customized email add
 - Docker (TODO)
 
 ## Setup Instructions
+Note: The following instructions were tested written on a _Windows 10_ system
+
 ### Certificates
 To create the self-signed certificates needed for the Nginx proxy configuration, you must have [OpenSSL](https://github.com/openssl/openssl) installed on your system.
 After installing OpenSSL:
-1. Open a terminal/CMD window
-2. Navigate to the project root directory (TODO images)
-3. Create a "**/certs**" directory
-4. To generate a self-signed certificate run ```bash openssl req -x509 -nodes -days 365 -newkey rsa:2048 -keyout certs/nginx.key -out certs/nginx.crt -subj "/C=US/ST=Denial/L=Springfield/O=Dis/CN=www.localhost.com"```
+1. Open a CMD window
+2. Navigate to the **nginx** folder in project root directory (TODO images)
+3. Create a "**/certs**" directory, run ```mkdir certs```
+4. To generate a self-signed certificate run ```openssl req -x509 -nodes -days 365 -newkey rsa:2048 -keyout certs/nginx.key -out certs/nginx.crt -subj "/C=US/ST=Denial/L=Springfield/O=Dis/CN=www.localhost.com"```
 
-This will create a **.crt** and **.key** file in **\certs** directory, which is referenced in [docker-compose.yml]() and [nginx.conf]()
+This will create a **.crt** and **.key** file in the **\nginx\certs** directory. Note that it is referenced in [docker-compose.yml]() and must be updated in both places in the case of a change.
 
 ### Running the docker-compose bundle locally
-To run the configuration described inside [docker.compose.yml]() you must have [Docker](https://docs.docker.com/engine/install/) installed on your system.
+To run the configuration described inside the [docker.compose.yml](), you must have [Docker](https://docs.docker.com/engine/install/) installed on your system.
 After installing Docker:
-1. Open a terminal/CMD window
+1. Open a CMD window
 2. Navigate to the project root directory
-3. run ```bash docker compose up```
+3. Run ```docker compose up```
 
-This will build the new service Docker image described in the [Dockerfile]() and pull the Nginx image
+This will build the new service Docker image described in the [Dockerfile]() and pull and run the Nginx image
 
 (TODO)
 ## Custom Expression Language

--- a/README.md
+++ b/README.md
@@ -11,7 +11,25 @@ The Dynamic Email Generator is a service designed to create customized email add
 - Docker (TODO)
 
 ## Setup Instructions
-(TODO)
+### Certificates
+To create the self-signed certificates needed for the Nginx proxy configuration, you must have [OpenSSL](https://github.com/openssl/openssl) installed on your system.
+After installing OpenSSL:
+1. Open a terminal/CMD window
+2. Navigate to the project root directory (TODO images)
+3. Create a "**/certs**" directory
+4. To generate a self-signed certificate run ```bash openssl req -x509 -nodes -days 365 -newkey rsa:2048 -keyout certs/nginx.key -out certs/nginx.crt -subj "/C=US/ST=Denial/L=Springfield/O=Dis/CN=www.localhost.com"```
 
+This will create a **.crt** and **.key** file in **\certs** directory, which is referenced in [docker-compose.yml]() and [nginx.conf]()
+
+### Running the docker-compose bundle locally
+To run the configuration described inside [docker.compose.yml]() you must have [Docker](https://docs.docker.com/engine/install/) installed on your system.
+After installing Docker:
+1. Open a terminal/CMD window
+2. Navigate to the project root directory
+3. run ```bash docker compose up```
+
+This will build the new service Docker image described in the [Dockerfile]() and pull the Nginx image
+
+(TODO)
 ## Custom Expression Language
 (TODO language rules)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,7 @@ services:
       - service-network
 
   nginx:
-    image: nginx:latest #TODO choose a stable version
+    image: nginx:latest
     ports:
       - "9443:443"
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,8 +15,9 @@ services:
     ports:
       - "9443:443"
     volumes:
-      - ./nginx.conf:/etc/nginx/nginx.conf
-      - ./certs:/etc/nginx/certs
+      - ./nginx/nginx.conf:/etc/nginx/nginx.conf
+      - ./nginx/certs:/etc/nginx/certs
+      - ./nginx/error_pages:/usr/share/nginx/html
     depends_on:
       - email-generator-service
     networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,27 @@
+version: '3.8'
+services:
+  email-generator-service:
+    image: email-generator-service
+    build:
+      dockerfile: Dockerfile
+    ports:
+      # TODO do not expose this service to the outside world for production builds
+      - "8080:8080"
+    networks:
+      - service-network
+
+  nginx:
+    image: nginx:latest #TODO choose a stable version
+    ports:
+      - "9443:443"
+    volumes:
+      - ./nginx.conf:/etc/nginx/nginx.conf
+      - ./certs:/etc/nginx/certs
+    depends_on:
+      - email-generator-service
+    networks:
+      - service-network
+
+networks:
+  service-network:
+    driver: bridge

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,34 @@
+worker_processes 1;
+
+events { worker_connections 1024; }
+
+http {
+    sendfile on;
+    upstream app {
+        server email-generator-service:8080;
+    }
+
+    server {
+        listen 443 ssl;
+
+        # TODO kind of hacky https upgrade, should we just drop http requests?
+        error_page 497 https://$host:$server_port$request_uri;
+
+        ssl_certificate /etc/nginx/certs/nginx.crt;
+        ssl_certificate_key /etc/nginx/certs/nginx.key;
+
+        ssl_protocols TLSv1.2 TLSv1.3;
+        ssl_ciphers 'ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384';
+        ssl_prefer_server_ciphers on;
+
+        add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
+
+        location / {
+            proxy_pass http://email-generator-service:8080;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+        }
+    }
+}

--- a/nginx/error_pages/50x.html
+++ b/nginx/error_pages/50x.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <title>Service Unavailable</title>
+</head>
+<body>
+    <h1>Service Unavailable</h1>
+    <p>The service is temporarily unavailable. Please try again later.</p>
+</body>
+</html>

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -3,7 +3,6 @@ worker_processes 1;
 events { worker_connections 1024; }
 
 http {
-    sendfile on;
     upstream app {
         server email-generator-service:8080;
     }
@@ -24,11 +23,23 @@ http {
         add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
 
         location / {
-            proxy_pass http://email-generator-service:8080;
+            proxy_pass http://app;
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Proto $scheme;
+
+            # proxy timeouts for reaching the backend service
+            proxy_connect_timeout 5s;
+            proxy_send_timeout 10s;
+            proxy_read_timeout 10s;
+        }
+
+        # Capture unexpected errors so we don't leak server info
+        error_page 500 502 503 504 /50x.html;
+        location = /50x.html {
+            root /usr/share/nginx/html;
+            internal;
         }
     }
 }

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -35,7 +35,7 @@ http {
             proxy_read_timeout 10s;
         }
 
-        # Capture unexpected errors so we don't leak server info
+        # Capture unexpected errors gracefully
         error_page 500 502 503 504 /50x.html;
         location = /50x.html {
             root /usr/share/nginx/html;

--- a/pom.xml
+++ b/pom.xml
@@ -2,20 +2,24 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
         <version>3.2.5</version>
-        <relativePath/> <!-- lookup parent from repository -->
+        <relativePath/>
     </parent>
+
     <groupId>com.stdnullptr</groupId>
     <artifactId>Dynamic-Email-Generator</artifactId>
     <version>0.0.1-SNAPSHOT</version>
     <name>Dynamic-Email-Generator</name>
     <description>Dynamic-Email-Generator</description>
+
     <properties>
         <java.version>21</java.version>
     </properties>
+
     <dependencies>
         <dependency>
             <groupId>org.springframework.boot</groupId>


### PR DESCRIPTION
## Overview
This PR introduces containerizing the Spring Boot service using Docker. Added a docker-compose file to orchestrate the service container and an additional Nginx container to serve as a proxy and handle SSL termination. Also updated the README file to reflect the changes and provide guidance in setting up the proxy and running the service locally.

## Related Issues
Resolves #4 - Containerize the application

## Testing Instructions
1. Checkout the branch and build the project with `mvn clean package`.
2. Follow the instructions in the README, that is part of this PR, to setup certificates ("Certificates" section in README)
3. Follow the instructions in the README, that is part of this PR, to run the service locally ("Running the docker-compose bundle locally" section in README)
4. Use the following CURL commands to test the endpoint:
   ```bash
   curl https://localhost:9443/app/v1/health
   curl http://localhost:9443/app/v1/health
5. Verify the response is as expected:
The HTTP request should be upgraded and forwarded to HTTPS, and you should receive a 200 response in both cases. The health check endpoint also logs to the service console the message "Health check called", so that you can easily verify that the service is being hit.