### PR TITLE
Implement conditional expressions - equality and string length compar…

### DIFF
--- a/src/main/java/com/stdnullptr/emailgenerator/service/interpreter/EqualityExpression.java
+++ b/src/main/java/com/stdnullptr/emailgenerator/service/interpreter/EqualityExpression.java
@@ -1,0 +1,18 @@
+package com.stdnullptr.emailgenerator.service.interpreter;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+class EqualityExpression implements Expression {
+    private final Expression left;
+    private final Expression right;
+    private final Expression action;
+
+    @Override
+    public String interpret(Context ctx) {
+        if (left.interpret(ctx).equals(right.interpret(ctx))){
+            return action.interpret(ctx);
+        }
+        return ""; // If we did not meet the condition, just return an empty string
+    }
+}

--- a/src/main/java/com/stdnullptr/emailgenerator/service/interpreter/Expression.java
+++ b/src/main/java/com/stdnullptr/emailgenerator/service/interpreter/Expression.java
@@ -1,5 +1,5 @@
 package com.stdnullptr.emailgenerator.service.interpreter;
 
-interface Expression<T> {
-    T interpret(Context ctx);
+interface Expression {
+    String interpret(Context ctx);
 }

--- a/src/main/java/com/stdnullptr/emailgenerator/service/interpreter/ExpressionFactory.java
+++ b/src/main/java/com/stdnullptr/emailgenerator/service/interpreter/ExpressionFactory.java
@@ -3,30 +3,79 @@ package com.stdnullptr.emailgenerator.service.interpreter;
 import com.stdnullptr.emailgenerator.exception.InterpreterException;
 import lombok.extern.slf4j.Slf4j;
 
-import java.util.stream.Stream;
+import java.util.ArrayList;
+import java.util.List;
 
 @Slf4j
 class ExpressionFactory {
 
-    static Expression<String> createExpression(String expression) {
-        String[] tokens = Stream.of(
-                expression.split("[(),]")).filter(w -> !w.isEmpty()).map(String::trim).toArray(String[]::new);
-
-        if (tokens.length < 2) {
-            log.error("Invalid expression, too few tokens after parsing: {}", expression);
-            throw new InterpreterException("Failed to parse expression");
+    static Expression createExpression(String expression) {
+        int firstParen = expression.indexOf('(');
+        if (firstParen == -1 || !expression.endsWith(")")) {
+            log.error("Invalid expression format: {}", expression);
+            throw new InterpreterException("Expression must start with an operation name and follow with parameters in parentheses.");
         }
 
-        Operations operation = Operations.valueOf(tokens[0].toUpperCase());
-        String firstParam = tokens[1];
+        String operationName = expression.substring(0, firstParen).trim();
+        String parameterString = expression.substring(firstParen + 1, expression.length() - 1).trim();
+        List<String> parameters = parseParameters(parameterString);
+        if (parameters.isEmpty()) {
+            throw new InterpreterException("Expression has no parameters");
+        }
+
+        Operations operation = Operations.valueOf(operationName.toUpperCase());
 
         return switch (operation) {
-            case FIRST -> new FirstCharsExpression(firstParam, Integer.parseInt(tokens[2]));
-            case LAST -> new LastCharsExpression(firstParam, Integer.parseInt(tokens[2]));
-            case LIT -> new LiteralExpression(firstParam);
-            case RAW -> new RawExpression(firstParam);
+            case FIRST -> new FirstCharsExpression(parameters.get(0), Integer.parseInt(parameters.get(1)));
+            case LAST -> new LastCharsExpression(parameters.get(0), Integer.parseInt(parameters.get(1)));
+            case LIT -> new LiteralExpression(parameters.get(0));
+            case RAW -> new RawExpression(parameters.get(0));
             case SUBSTR ->
-                    new SubstringExpression(firstParam, Integer.parseInt(tokens[2]), Integer.parseInt(tokens[3]));
+                    new SubstringExpression(parameters.get(0), Integer.parseInt(parameters.get(1)), Integer.parseInt(parameters.get(2)));
+            case EQ -> new EqualityExpression(
+                    createExpression(parameters.get(0)),
+                    createExpression(parameters.get(1)),
+                    createExpression(parameters.get(2)));
+            case LONGER -> new LengthComparisonExpression(
+                    createExpression(parameters.get(0)),
+                    createExpression(parameters.get(1)),
+                    createExpression(parameters.get(2))
+            );
         };
+    }
+
+    private static List<String> parseParameters(String params) {
+        List<String> resultParameters = new ArrayList<>();
+        int balance = 0;
+        StringBuilder currentParam = new StringBuilder();
+
+        for (char c : params.toCharArray()) {
+            switch (c) {
+                case '(':
+                    balance++;
+                    currentParam.append(c);
+                    break;
+                case ')':
+                    balance--;
+                    currentParam.append(c);
+                    break;
+                case ',':
+                    if (balance == 0) {
+                        resultParameters.add(currentParam.toString().trim());
+                        currentParam.setLength(0);
+                    } else {
+                        currentParam.append(c);
+                    }
+                    break;
+                default:
+                    currentParam.append(c);
+            }
+        }
+
+        if (!currentParam.isEmpty()) {
+            resultParameters.add(currentParam.toString().trim());
+        }
+
+        return resultParameters;
     }
 }

--- a/src/main/java/com/stdnullptr/emailgenerator/service/interpreter/FirstCharsExpression.java
+++ b/src/main/java/com/stdnullptr/emailgenerator/service/interpreter/FirstCharsExpression.java
@@ -4,7 +4,7 @@ import com.stdnullptr.emailgenerator.exception.InterpreterException;
 import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
-class FirstCharsExpression implements Expression<String> {
+class FirstCharsExpression implements Expression {
     private final String inputKey;
     private final int numCharacters;
 

--- a/src/main/java/com/stdnullptr/emailgenerator/service/interpreter/InterpreterService.java
+++ b/src/main/java/com/stdnullptr/emailgenerator/service/interpreter/InterpreterService.java
@@ -13,8 +13,8 @@ public class InterpreterService {
         String[] expressions = Stream.of(fullExpressionString.split(";")).map(String::trim).toArray(String[]::new);
 
         for (String expression : expressions) {
-            if (Operations.isStringExpression(expression)) {
-                Expression<String> exp = ExpressionFactory.createExpression(expression);
+            if (Operations.isOperation(expression)) {
+                Expression exp = ExpressionFactory.createExpression(expression);
                 result.append(exp.interpret(context));
             } else {
                 throw new InterpreterException("Unknown expression: " + expression);

--- a/src/main/java/com/stdnullptr/emailgenerator/service/interpreter/LastCharsExpression.java
+++ b/src/main/java/com/stdnullptr/emailgenerator/service/interpreter/LastCharsExpression.java
@@ -4,7 +4,7 @@ import com.stdnullptr.emailgenerator.exception.InterpreterException;
 import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
-class LastCharsExpression implements Expression<String> {
+class LastCharsExpression implements Expression {
     private final String inputKey;
     private final int numCharacters;
 

--- a/src/main/java/com/stdnullptr/emailgenerator/service/interpreter/LengthComparisonExpression.java
+++ b/src/main/java/com/stdnullptr/emailgenerator/service/interpreter/LengthComparisonExpression.java
@@ -1,0 +1,18 @@
+package com.stdnullptr.emailgenerator.service.interpreter;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+class LengthComparisonExpression implements Expression {
+    private final Expression left;
+    private final Expression right;
+    private final Expression action;
+
+    @Override
+    public String interpret(Context ctx) {
+        if (left.interpret(ctx).length() > right.interpret(ctx).length()) {
+            return action.interpret(ctx);
+        }
+        return ""; // If we did not meet the condition, just return an empty string
+    }
+}

--- a/src/main/java/com/stdnullptr/emailgenerator/service/interpreter/LiteralExpression.java
+++ b/src/main/java/com/stdnullptr/emailgenerator/service/interpreter/LiteralExpression.java
@@ -4,7 +4,7 @@ import com.stdnullptr.emailgenerator.exception.InterpreterException;
 import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
-class LiteralExpression implements Expression<String> {
+class LiteralExpression implements Expression {
     private final String inputKey;
 
     @Override

--- a/src/main/java/com/stdnullptr/emailgenerator/service/interpreter/Operations.java
+++ b/src/main/java/com/stdnullptr/emailgenerator/service/interpreter/Operations.java
@@ -3,24 +3,23 @@ package com.stdnullptr.emailgenerator.service.interpreter;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
-import java.util.EnumSet;
+import java.util.Arrays;
 
 @Getter
 @RequiredArgsConstructor
-public enum Operations {
+enum Operations {
     FIRST("first"),
     LAST("last"),
     SUBSTR("substr"),
     LIT("lit"),
-    RAW("raw");
-
-    private static final EnumSet<Operations> stringOperations =
-            EnumSet.of(FIRST, LAST, SUBSTR, LIT, RAW);
+    RAW("raw"),
+    EQ("eq"),
+    LONGER("longer");
 
     private final String operationName;
 
-    public static boolean isStringExpression(String expr) {
-        return stringOperations.stream().anyMatch(op -> expr.startsWith(op.toString()));
+    public static boolean isOperation(String operationName) {
+        return Arrays.stream(Operations.values()).anyMatch(op -> operationName.startsWith(op.toString()));
     }
 
     @Override

--- a/src/main/java/com/stdnullptr/emailgenerator/service/interpreter/RawExpression.java
+++ b/src/main/java/com/stdnullptr/emailgenerator/service/interpreter/RawExpression.java
@@ -3,7 +3,7 @@ package com.stdnullptr.emailgenerator.service.interpreter;
 import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
-class RawExpression implements Expression<String> {
+class RawExpression implements Expression {
     private final String value;
 
     @Override

--- a/src/main/java/com/stdnullptr/emailgenerator/service/interpreter/SubstringExpression.java
+++ b/src/main/java/com/stdnullptr/emailgenerator/service/interpreter/SubstringExpression.java
@@ -4,7 +4,7 @@ import com.stdnullptr.emailgenerator.exception.InterpreterException;
 import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
-class SubstringExpression implements Expression<String> {
+class SubstringExpression implements Expression {
     private final String inputKey;
     private final int startIndex;
     private final int endIndex;

--- a/src/test/java/com/stdnullptr/emailgenerator/util/Utils.java
+++ b/src/test/java/com/stdnullptr/emailgenerator/util/Utils.java
@@ -62,9 +62,21 @@ public final class Utils {
                         add("str1", "Millennium");
                         add("expression", "unknown(str1)");
                     }}),
-                    createErrorTestEntry("Failed to parse expression", new LinkedMultiValueMap<>() {{
+                    createErrorTestEntry("Expression has no parameters", new LinkedMultiValueMap<>() {{
                         add("str1", "Millennium");
                         add("expression", "first()");
+                    }}),
+                    createErrorTestEntry("Expression must start with an operation name and follow with parameters in parentheses.", new LinkedMultiValueMap<>() {{
+                        add("str1", "Millennium");
+                        add("expression", "first(");
+                    }}),
+                    createErrorTestEntry("Expression must start with an operation name and follow with parameters in parentheses.", new LinkedMultiValueMap<>() {{
+                        add("str1", "Millennium");
+                        add("expression", "first(str1, Millennium");
+                    }}),
+                    createErrorTestEntry("Expression must start with an operation name and follow with parameters in parentheses.", new LinkedMultiValueMap<>() {{
+                        add("str1", "Millennium");
+                        add("expression", "first)");
                     }}),
                     createErrorTestEntry("Input value is null for input key: str2", new LinkedMultiValueMap<>() {{
                         add("str1", "Millennium");


### PR DESCRIPTION
## Overview
Enhanced the custom expression language with conditional non-terminal operations.
Refer to #11 for examples.

## Related Issues
Resolves #11 - Implement Conditional Expressions

## Testing Instructions
1. Checkout the branch and build the project with `mvn clean package`.
2. Follow the instructions in the README, to setup certificates ("Certificates" section in README)
3. Follow the instructions in the README, to run the service locally ("Running the docker-compose bundle locally" section in README)
4. Use the following CURL command to test the endpoint (refer to #2 for query param syntax):
   ```bash
   curl https://localhost:9443/app/v1/email/generate?str1=Ivan&str1=Nikola&str1=Rado&str2=gmail&str2=yahoo&str3=com&str3=bg&expression=longer(lit(str1)%2Clit(str2)%2Clit(str3))%3Beq(lit(str1)%2Clit(str2)%2Clit(str3))%3Bfirst(str1%2C2)%20%3B%20raw(.)%20%3B%20lit(str1)%20%3B%20raw(%40)%20%3B%20first(str2%2C%204)%20%3B%20raw(.)%20%3B%20lit(str3)
5. You should get the following response: 
    ```json
    {
        "data": [
            "Iv.Ivan@gmai.com",
            "Iv.Ivan@gmai.bg",
            "Iv.Ivan@yaho.com",
            "Iv.Ivan@yaho.bg",
            "comNi.Nikola@gmai.com",
            "bgNi.Nikola@gmai.bg",
            "comNi.Nikola@yaho.com",
            "bgNi.Nikola@yaho.bg",
            "Ra.Rado@gmai.com",
            "Ra.Rado@gmai.bg",
            "Ra.Rado@yaho.com",
            "Ra.Rado@yaho.bg"
        ],
        "message": null
    }

Query params decoded:
str1: Ivan, Nikola, Rado
str2: gmail, yahoo
str3: com, bg
expression: longer(lit(str1),lit(str2),lit(str3));eq(lit(str1),lit(str2),lit(str3));first(str1,2) ; raw(.) ; lit(str1) ; raw(@) ; first(str2, 4) ; raw(.) ; lit(str3)

